### PR TITLE
Updated script install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 To install, run the installation script:
 
 ```
-curl https://raw.github.com/github-flow/github-flow/v1.1/install.sh | $(which bash)
+curl https://raw.githubusercontent.com/github-flow/github-flow/v1.1/install.sh | $(which bash)
 ```
 
 To update, run the install script again.


### PR DESCRIPTION
https://raw.github.com/github-flow/github-flow/v1.1/install.sh was issuing redirect to https://raw.githubusercontent.com/github-flow/github-flow/v1.1/install.sh which was not being followed by the default `curl` options.

Updated README.md to point to new URL.